### PR TITLE
Update repo name in the mkdocs file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,11 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: ["buildstock_fetcher"]
+          paths: ["buildstock_fetch"]
+          options:
+            show_source: true
+            show_root_heading: true
+            heading_level: 2
 theme:
   name: material
   feature:


### PR DESCRIPTION
## Summary

This PR fixes the issue of modules not rendering in the documentation.

## Changes

-  Update the repo name buildstock_fetcher to buildstock_fetch in the makedocs configuration file

Closes #10 