### PR TITLE
Add automatic documentation deployment everytime there's a push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,3 +62,16 @@ jobs:
 
       - name: Check if documentation can be built
         run: uv run mkdocs build -s
+
+  deploy-docs:
+    needs: check-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Deploy documentation
+        run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

This PR adds automatic documentation deployment to main.yml. Currently we have this code only in "on-release.main.yml", meaning the documentation gets updated only when there's a release. With this addition, the documentation gets updated whenever there's a push to the main branch.

Closes #10 

