### PR TITLE
Change resstock release parameter input for BuildingID's

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,18 @@ def test_fetch_bldg_ids():
     ]
 
 
+def test_building_id_config():
+    res_2024_amy = {"release_number": "1", "release_year": "2022", "res_com": "resstock", "weather": "tmy3"}
+
+    bldg = BuildingID(bldg_id=7, **res_2024_amy)
+    assert bldg.bldg_id == 7
+    assert bldg.upgrade_id == "0"
+    assert bldg.release_number == "1"
+    assert bldg.release_year == "2022"
+    assert bldg.weather == "tmy3"
+    assert bldg.res_com == "resstock"
+
+
 def test_fetch_bldg_data(cleanup_downloads):
     fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)])
     assert Path("data/0000007_upgrade0.zip").exists()


### PR DESCRIPTION
## Summary

This PR adds a test for changing the resstock release parameters. Currently, we provide each parameter separately. With this update, it should take in a dictionary containing release number, release year, weather version, and resstock/comstock version. 

Closes #2 