### PR TITLE
Add script for fetching building data

### DIFF
--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -99,8 +99,12 @@ def fetch_bldg_data_core(bldg_ids: list[BuildingID], file_type: list[str], outpu
                     if xml_files:
                         xml_file = xml_files[0]  # Take the first (and only) XML file
                         zip_ref.extract(xml_file, output_dir)
-                        extracted_path = output_dir / xml_file
-                        downloaded_paths.append(extracted_path)
+                        # Rename to the specified convention
+                        old_path = output_dir / xml_file
+                        new_name = f"bldg{bldg_id.bldg_id:07}-up{bldg_id.upgrade_id:02}.xml"
+                        new_path = output_dir / new_name
+                        old_path.rename(new_path)
+                        downloaded_paths.append(new_path)
 
                 if "schedule" in file_type:
                     # Find and extract the schedule CSV file
@@ -108,10 +112,16 @@ def fetch_bldg_data_core(bldg_ids: list[BuildingID], file_type: list[str], outpu
                     if schedule_files:
                         schedule_file = schedule_files[0]  # Take the first (and only) schedule file
                         zip_ref.extract(schedule_file, output_dir)
-                        extracted_path = output_dir / schedule_file
-                        downloaded_paths.append(extracted_path)
+                        # Rename to the specified convention
+                        old_path = output_dir / schedule_file
+                        new_name = f"bldg{bldg_id.bldg_id:07}-up{bldg_id.upgrade_id:02}_schedule.csv"
+                        new_path = output_dir / new_name
+                        old_path.rename(new_path)
+                        downloaded_paths.append(new_path)
 
-        downloaded_paths.append(output_file)
+            # Remove the zip file after extraction
+            output_file.unlink()
+
     return downloaded_paths
 
 

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -16,13 +16,18 @@ class BuildingID:
     res_com: str = "resstock"
     weather: str = "tmy3"
     upgrade_id: str = "0"
+    base_url: str = (
+        f"https://oedi-data-lake.s3.amazonaws.com/"
+        "nrel-pds-building-stock/"
+        "end-use-load-profiles-for-us-building-stock/"
+        f"{release_year}/"
+        f"{res_com}_{weather}_release_{release_number}/"
+    )
 
     def get_building_data_url(self) -> str:
         """Generate the S3 download URL for this building."""
         return (
-            "https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/"
-            f"end-use-load-profiles-for-us-building-stock/{self.release_year}/"
-            f"{self.res_com}_{self.weather}_release_{self.release_number}/"
+            f"{self.base_url}"
             f"building_energy_models/upgrade={self.upgrade_id}/"
             f"bldg{self.bldg_id:07}-up0{self.upgrade_id}.zip"
         )

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -59,16 +59,15 @@ def fetch_bldg_ids(state: str) -> list[BuildingID]:
         raise NotImplementedError(f"State {state} not supported")
 
 
-@click.command()
-@click.argument("file_type", nargs=-1, required=True)
-@click.option("output_dir", default=Path(__file__).parent.parent / "data")
-def fetch_bldg_data(bldg_ids: list[BuildingID], file_type: tuple[str], output_dir: Path) -> list[Path]:
+def fetch_bldg_data_core(bldg_ids: list[BuildingID], file_type: list[str], output_dir: Path) -> list[Path]:
     """Download building data for a given list of building ids
 
     Downloads the data for the given building ids and returns list of paths to the downloaded files.
 
     Args:
         bldg_ids: A list of BuildingID objects to download data for.
+        file_type: Tuple of file types to extract (e.g., "hpxml", "schedule")
+        output_dir: Directory to save the downloaded files.
 
     Returns:
         A list of paths to the downloaded files.
@@ -114,6 +113,24 @@ def fetch_bldg_data(bldg_ids: list[BuildingID], file_type: tuple[str], output_di
 
         downloaded_paths.append(output_file)
     return downloaded_paths
+
+
+@click.command()
+@click.argument("bldg_ids", nargs=-1, required=True)
+@click.argument("file_type", nargs=-1, required=True)
+@click.argument("output_dir", default=Path(__file__).parent / "data")
+def fetch_bldg_data(bldg_ids: list[BuildingID], file_type: tuple[str], output_dir: Path) -> list[Path]:
+    """Download building data for a given list of building ids
+
+    Downloads the data for the given building ids and returns list of paths to the downloaded files.
+
+    Args:
+        bldg_ids: A list of BuildingID objects to download data for.
+
+    Returns:
+        A list of paths to the downloaded files.
+    """
+    return fetch_bldg_data_core(bldg_ids, list(file_type), output_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+import click
 import requests
 
 
@@ -52,6 +53,7 @@ def fetch_bldg_ids(state: str) -> list[BuildingID]:
         raise NotImplementedError(f"State {state} not supported")
 
 
+@click.command()
 def fetch_bldg_data(bldg_ids: list[BuildingID]) -> list[Path]:
     """Download building data for a given list of building ids
 

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -54,7 +54,9 @@ def fetch_bldg_ids(state: str) -> list[BuildingID]:
 
 
 @click.command()
-def fetch_bldg_data(bldg_ids: list[BuildingID]) -> list[Path]:
+@click.argument("file_type", nargs=-1, required=True)
+@click.option("output_dir", default=Path(__file__).parent.parent / "data")
+def fetch_bldg_data(bldg_ids: list[BuildingID], file_type: tuple[str], output_dir: Path) -> list[Path]:
     """Download building data for a given list of building ids
 
     Downloads the data for the given building ids and returns list of paths to the downloaded files.
@@ -65,19 +67,22 @@ def fetch_bldg_data(bldg_ids: list[BuildingID]) -> list[Path]:
     Returns:
         A list of paths to the downloaded files.
     """
-    data_dir = Path(__file__).parent.parent / "data"
+    if isinstance(output_dir, str):
+        output_dir = Path(output_dir)
+    if not output_dir.exists():
+        os.makedirs(output_dir, exist_ok=True)
+
     downloaded_paths = []
-    os.makedirs(data_dir, exist_ok=True)
 
     for bldg_id in bldg_ids:
         response = requests.get(bldg_id.get_download_url(), timeout=30)
         response.raise_for_status()
 
-        output_path = data_dir / f"{bldg_id.bldg_id:07}_upgrade{bldg_id.upgrade_id}.zip"
-        with open(output_path, "wb") as file:
+        output_file = output_dir / f"{bldg_id.bldg_id:07}_upgrade{bldg_id.upgrade_id}.zip"
+        with open(output_file, "wb") as file:
             file.write(response.content)
 
-        downloaded_paths.append(output_path)
+        downloaded_paths.append(output_file)
     return downloaded_paths
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.32.3",
+    "click>=8.1.0",
 ]
 
 [project.urls]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,20 +47,20 @@ def test_fetch_bldg_data(cleanup_downloads):
     fetch_bldg_data_core(
         bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=["hpxml"], output_dir=Path("data")
     )
-    assert Path("data/0000007/bldg0000007.hpxml").exists()
-    assert Path("data/0000008/bldg0000008.hpxml").exists()
+    assert Path("data/bldg0000007-up00.xml").exists()
+    assert Path("data/bldg0000008-up00.xml").exists()
 
     fetch_bldg_data_core(
         bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=["schedule"], output_dir=Path("data")
     )
-    assert Path("data/0000007/bldg0000007.sched.h5").exists()
-    assert Path("data/0000008/bldg0000008.sched.h5").exists()
+    assert Path("data/bldg0000007-up00_schedule.csv").exists()
+    assert Path("data/bldg0000008-up00_schedule.csv").exists()
     fetch_bldg_data_core(
         bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)],
         file_type=["hpxml", "schedule"],
         output_dir=Path("data"),
     )
-    assert Path("data/0000007/bldg0000007.hpxml").exists()
-    assert Path("data/0000008/bldg0000008.hpxml").exists()
-    assert Path("data/0000007/bldg0000007.sched.h5").exists()
-    assert Path("data/0000008/bldg0000008.sched.h5").exists()
+    assert Path("data/bldg0000007-up00.xml").exists()
+    assert Path("data/bldg0000008-up00.xml").exists()
+    assert Path("data/bldg0000007-up00_schedule.csv").exists()
+    assert Path("data/bldg0000008-up00_schedule.csv").exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from buildstock_fetch.main import BuildingID, fetch_bldg_data, fetch_bldg_ids
+from buildstock_fetch.main import BuildingID, fetch_bldg_data_core, fetch_bldg_ids
 
 
 @pytest.fixture(scope="function")
@@ -44,15 +44,22 @@ def test_building_id_config():
 
 
 def test_fetch_bldg_data(cleanup_downloads):
-    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("hpxml"))
+    fetch_bldg_data_core(
+        bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=["hpxml"], output_dir=Path("data")
+    )
     assert Path("data/0000007/bldg0000007.hpxml").exists()
     assert Path("data/0000008/bldg0000008.hpxml").exists()
 
-    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("schedule"))
+    fetch_bldg_data_core(
+        bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=["schedule"], output_dir=Path("data")
+    )
     assert Path("data/0000007/bldg0000007.sched.h5").exists()
     assert Path("data/0000008/bldg0000008.sched.h5").exists()
-
-    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("hpxml", "schedule"))
+    fetch_bldg_data_core(
+        bldg_ids=[BuildingID(bldg_id=7), BuildingID(bldg_id=8)],
+        file_type=["hpxml", "schedule"],
+        output_dir=Path("data"),
+    )
     assert Path("data/0000007/bldg0000007.hpxml").exists()
     assert Path("data/0000008/bldg0000008.hpxml").exists()
     assert Path("data/0000007/bldg0000007.sched.h5").exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,16 @@ def test_building_id_config():
 
 
 def test_fetch_bldg_data(cleanup_downloads):
-    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)])
-    assert Path("data/0000007_upgrade0.zip").exists()
-    assert Path("data/0000008_upgrade0.zip").exists()
+    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("hpxml"))
+    assert Path("data/0000007/bldg0000007.hpxml").exists()
+    assert Path("data/0000008/bldg0000008.hpxml").exists()
+
+    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("schedule"))
+    assert Path("data/0000007/bldg0000007.sched.h5").exists()
+    assert Path("data/0000008/bldg0000008.sched.h5").exists()
+
+    fetch_bldg_data([BuildingID(bldg_id=7), BuildingID(bldg_id=8)], file_type=("hpxml", "schedule"))
+    assert Path("data/0000007/bldg0000007.hpxml").exists()
+    assert Path("data/0000008/bldg0000008.hpxml").exists()
+    assert Path("data/0000007/bldg0000007.sched.h5").exists()
+    assert Path("data/0000008/bldg0000008.sched.h5").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ name = "buildstock-fetch"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "requests" },
 ]
 
@@ -47,7 +48,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.3" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "requests", specifier = ">=2.32.3" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

This PR adds code to implement downloading building related data (i.e. hpxml and schedule files).

## Implementation details

1. The fetch_bldg_data() function has two versions: one that uses CLI and one that has the main functionality. The CLI version simply takes in command line arguments and passes them to the other one that contains the main functinality. 
2. file_type is a flag that can be passed to specify which files should be downloaded. If ```hpxml``` and/or ```schedule``` file is passed, then these files are downloaded (more precisely, the .zip file containing both is downlaoded, then each of the files extracted from it, and the zip file removed)
3. The naming convention for both is: ```bldg{bldg_id:07}-up{upgrade_id:02}.xml``` for hpxml files and ```bldg{bldg_id:07}-up{upgrade_id:02}_schedule.csv``` for the schedule file. For example ```bldg0000007-up00.xml``` or ```bldg0000008-up10_schedule.csv```.
4. Appropriate tests have been added in test_main.py
