### PR TITLE
38 add appropriate download urls for all releases

### DIFF
--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -49,13 +49,16 @@ class BuildingID:
     weather: str = "tmy3"
     upgrade_id: str = "0"
     state: str = "NY"
-    base_url: str = (
-        f"https://oedi-data-lake.s3.amazonaws.com/"
-        "nrel-pds-building-stock/"
-        "end-use-load-profiles-for-us-building-stock/"
-        f"{release_year}/"
-        f"{res_com}_{weather}_release_{release_number}/"
-    )
+
+    @property
+    def base_url(self) -> str:
+        return (
+            f"https://oedi-data-lake.s3.amazonaws.com/"
+            "nrel-pds-building-stock/"
+            "end-use-load-profiles-for-us-building-stock/"
+            f"{self.release_year}/"
+            f"{self.res_com}_{self.weather}_release_{self.release_number}/"
+        )
 
     def get_building_data_url(self) -> str:
         """Generate the S3 download URL for this building."""
@@ -333,6 +336,8 @@ def fetch_bldg_data(
                     failed_downloads.append(
                         f"bldg{str(bldg_id.bldg_id).zfill(7)}-up{bldg_id.upgrade_id.zfill(2)}_schedule.csv"
                     )
+            except NoBuildingDataError:
+                raise
             except Exception as e:
                 print(f"Download failed for bldg_id {bldg_id}: {e}")
 

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -132,6 +132,46 @@ class BuildingID:
         else:
             return ""
 
+    def get_15min_timeseries_url(self) -> str:
+        """Generate the S3 download URL for this building."""
+        if self.release_year == "2021":
+            if self.upgrade_id != "0":
+                return ""  # This release only has baseline timeseries
+            else:
+                return (
+                    f"{self.base_url}timeseries_individual_buildings/"
+                    f"by_state/upgrade={self.upgrade_id}/"
+                    f"state={self.state}/"
+                    f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+                )
+
+        elif self.release_year == "2022" or self.release_year == "2023":
+            return (
+                f"{self.base_url}timeseries_individual_buildings/"
+                f"by_state/upgrade={self.upgrade_id}/"
+                f"state={self.state}/"
+                f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+            )
+        elif self.release_year == "2024":
+            if self.res_com == "resstock" and self.weather == "tmy3" and self.release_number == "1":
+                return ""
+            else:
+                return (
+                    f"{self.base_url}timeseries_individual_buildings/"
+                    f"by_state/upgrade={self.upgrade_id}/"
+                    f"state={self.state}/"
+                    f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+                )
+        elif self.release_year == "2025":
+            return (
+                f"{self.base_url}timeseries_individual_buildings/"
+                f"by_state/upgrade={self.upgrade_id}/"
+                f"state={self.state}/"
+                f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+            )
+        else:
+            return ""
+
     def get_release_name(self) -> str:
         """Generate the release name for this building."""
         res_com_str = "res" if self.res_com == "resstock" else "com"

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -94,13 +94,37 @@ class BuildingID:
 
     def get_metadata_url(self) -> str:
         """Generate the S3 download URL for this building."""
-        if self.res_com == "resstock" and self.weather == "tmy3" and self.release_year == "2022":
+
+        if self.release_year == "2021":
+            return f"{self.base_url}metadata/metadata.parquet"
+        elif self.release_year == "2022" or self.release_year == "2023":
             if self.upgrade_id == "0":
                 return f"{self.base_url}metadata/baseline.parquet"
             else:
                 return f"{self.base_url}metadata/upgrade{str(int(self.upgrade_id)).zfill(2)}.parquet"
+        elif self.release_year == "2024":
+            if self.res_com == "comstock" and self.weather == "amy2018" and self.release_number == "2":
+                return ""
+                # This release does not have a single national metadata file.
+                # Instead, it has a metadata file for each county.
+                # We need a way to download them all and combine based on the state
+            else:
+                if self.upgrade_id == "0":
+                    return f"{self.base_url}metadata/baseline.parquet"
+                else:
+                    return f"{self.base_url}metadata/upgrade{str(int(self.upgrade_id)).zfill(2)}.parquet"
+        elif (
+            self.release_year == "2025"
+            and self.res_com == "comstock"
+            and self.weather == "amy2018"
+            and self.release_number == "1"
+        ):
+            return ""
+            # This release does not have a single national metadata file.
+            # Instead, it has a metadata file for each county.
+            # We need a way to download them all and combine based on the state
         else:
-            return f"{self.base_url}metadata/metadata.parquet"
+            return ""
 
     def get_release_name(self) -> str:
         """Generate the release name for this building."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 from buildstock_fetch.main import (
     BuildingID,
     NoBuildingDataError,
+    NoMetadataError,
     RequestedFileTypes,
     _parse_requested_file_type,
     download_bldg_data,
@@ -162,7 +163,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for resstock_tmy3_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2023 release - should raise NoBuildingDataError
@@ -170,7 +173,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for comstock_amy2018_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2024 comstock release - should raise NoBuildingDataError
@@ -178,7 +183,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for comstock_amy2018_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2024 resstock release - should work fine
@@ -198,3 +205,43 @@ def test_fetch_bldg_data(cleanup_downloads):
     assert Path(
         f"data/{bldg_ids[0].get_release_name()}/schedule/{bldg_ids[0].state}/bldg0000007-up01_schedule.csv"
     ).exists()
+
+
+def test_fetch_metadata(cleanup_downloads):
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2024", res_com="resstock", weather="tmy3", upgrade_id="1", release_number="2"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    print(downloaded_paths)
+    print(failed_downloads)
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(f"data/{bldg_ids[0].get_release_name()}/metadata/{bldg_ids[0].state}/metadata.parquet").exists()
+
+    # Test 2024 comstock release - should raise NoMetadataError
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+
+    with pytest.raises(NoMetadataError, match=f"Metadata is not available for {bldg_ids[0].get_release_name()}"):
+        fetch_bldg_data(bldg_ids, file_type, output_dir)
+
+    # Test 2025 comstock release - should raise NoMetadataError
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2025", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="1"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+
+    with pytest.raises(NoMetadataError, match=f"Metadata is not available for {bldg_ids[0].get_release_name()}"):
+        fetch_bldg_data(bldg_ids, file_type, output_dir)


### PR DESCRIPTION
## Summary

This PR adds on to the existing function to return the download url paths for building data, metadata, and 15 min load profile. Each release version has different url paths for these files, and one function should be used to return appropriate download url paths.

## Implementation

The `get_building_data_url()` and other similar functions for metadata and 15 min load profile are fixed to address this issue.

Closes #38 