### PR TITLE
Create consistent column schema for end use load curve across all releases

### DIFF
--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -49,13 +49,16 @@ class BuildingID:
     weather: str = "tmy3"
     upgrade_id: str = "0"
     state: str = "NY"
-    base_url: str = (
-        f"https://oedi-data-lake.s3.amazonaws.com/"
-        "nrel-pds-building-stock/"
-        "end-use-load-profiles-for-us-building-stock/"
-        f"{release_year}/"
-        f"{res_com}_{weather}_release_{release_number}/"
-    )
+
+    @property
+    def base_url(self) -> str:
+        return (
+            f"https://oedi-data-lake.s3.amazonaws.com/"
+            "nrel-pds-building-stock/"
+            "end-use-load-profiles-for-us-building-stock/"
+            f"{self.release_year}/"
+            f"{self.res_com}_{self.weather}_release_{self.release_number}/"
+        )
 
     def get_building_data_url(self) -> str:
         """Generate the S3 download URL for this building."""
@@ -333,6 +336,8 @@ def fetch_bldg_data(
                     failed_downloads.append(
                         f"bldg{str(bldg_id.bldg_id).zfill(7)}-up{bldg_id.upgrade_id.zfill(2)}_schedule.csv"
                     )
+            except NoBuildingDataError:
+                raise
             except Exception as e:
                 print(f"Download failed for bldg_id {bldg_id}: {e}")
 

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -40,6 +40,21 @@ class No15minLoadCurveError(ValueError):
     pass
 
 
+COLUMN_RENAMES = {
+    "out.electricity.cooling.energy_consumption": ["out.electricity.cooling.energy_consumption"],
+    "out.electricity.heating.energy_consumption": ["out.electricity.heating.energy_consumption"],
+    "out.natural_gas.heating.energy_consumption": ["out.natural_gas.heating.energy_consumption"],
+    "out.natural_gas.water_systems.energy_consumption": ["out.natural_gas.water_systems.energy_consumption"],
+    "out.electricity.total.energy_consumption": ["out.electricity.total.energy_consumption"],
+    "out.natural_gas.total.energy_consumption": ["out.natural_gas.total.energy_consumption"],
+    "out.other_fuel.heating.energy_consumption": ["out.other_fuel.heating.energy_consumption"],
+    "out.other_fuel.water_systems.energy_consumption": ["out.other_fuel.water_systems.energy_consumption"],
+    "out.other_fuel.total.energy_consumption": ["out.other_fuel.total.energy_consumption"],
+    "out.site_energy.total.energy_consumption": ["out.site_energy.total.energy_consumption"],
+    "bldg_id": ["bldg_id"],
+}
+
+
 @dataclass
 class RequestedFileTypes:
     hpxml: bool = False

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -132,6 +132,46 @@ class BuildingID:
         else:
             return ""
 
+    def get_15min_timeseries_url(self) -> str:
+        """Generate the S3 download URL for this building."""
+        if self.release_year == "2021":
+            if self.upgrade_id != "0":
+                return ""  # This release only has baseline timeseries
+            else:
+                return (
+                    f"{self.base_url}timeseries_individual_buildings/"
+                    f"by_state/upgrade={self.upgrade_id}/"
+                    f"state={self.state}/"
+                    f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+                )
+
+        elif self.release_year == "2022" or self.release_year == "2023":
+            return (
+                f"{self.base_url}timeseries_individual_buildings/"
+                f"by_state/upgrade={self.upgrade_id}/"
+                f"state={self.state}/"
+                f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+            )
+        elif self.release_year == "2024":
+            if self.res_com == "resstock" and self.weather == "tmy3" and self.release_number == "1":
+                return ""
+            else:
+                return (
+                    f"{self.base_url}timeseries_individual_buildings/"
+                    f"by_state/upgrade={self.upgrade_id}/"
+                    f"state={self.state}/"
+                    f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+                )
+        elif self.release_year == "2025":
+            return (
+                f"{self.base_url}timeseries_individual_buildings/"
+                f"by_state/upgrade={self.upgrade_id}/"
+                f"state={self.state}/"
+                f"bldg{self.bldg_id!s}-up{int(self.upgrade_id)!s}.parquet"
+            )
+        else:
+            return ""
+
     def get_release_name(self) -> str:
         """Generate the release name for this building."""
         res_com_str = "res" if self.res_com == "resstock" else "com"

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -94,13 +94,37 @@ class BuildingID:
 
     def get_metadata_url(self) -> str:
         """Generate the S3 download URL for this building."""
-        if self.res_com == "resstock" and self.weather == "tmy3" and self.release_year == "2022":
+
+        if self.release_year == "2021":
+            return f"{self.base_url}metadata/metadata.parquet"
+        elif self.release_year == "2022" or self.release_year == "2023":
             if self.upgrade_id == "0":
                 return f"{self.base_url}metadata/baseline.parquet"
             else:
                 return f"{self.base_url}metadata/upgrade{str(int(self.upgrade_id)).zfill(2)}.parquet"
+        elif self.release_year == "2024":
+            if self.res_com == "comstock" and self.weather == "amy2018" and self.release_number == "2":
+                return ""
+                # This release does not have a single national metadata file.
+                # Instead, it has a metadata file for each county.
+                # We need a way to download them all and combine based on the state
+            else:
+                if self.upgrade_id == "0":
+                    return f"{self.base_url}metadata/baseline.parquet"
+                else:
+                    return f"{self.base_url}metadata/upgrade{str(int(self.upgrade_id)).zfill(2)}.parquet"
+        elif (
+            self.release_year == "2025"
+            and self.res_com == "comstock"
+            and self.weather == "amy2018"
+            and self.release_number == "1"
+        ):
+            return ""
+            # This release does not have a single national metadata file.
+            # Instead, it has a metadata file for each county.
+            # We need a way to download them all and combine based on the state
         else:
-            return f"{self.base_url}metadata/metadata.parquet"
+            return ""
 
     def get_release_name(self) -> str:
         """Generate the release name for this building."""

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -166,10 +166,17 @@ class BuildingID:
                     f"{self.bldg_id!s}-{int(self.upgrade_id)!s}.parquet"
                 )
 
-        elif self.release_year == "2022" or self.release_year == "2023":
+        elif self.release_year == "2022":
             return (
                 f"{self.base_url}timeseries_individual_buildings/"
                 f"by_state/upgrade={self.upgrade_id}/"
+                f"state={self.state}/"
+                f"{self.bldg_id!s}-{int(self.upgrade_id)!s}.parquet"
+            )
+        elif self.release_year == "2023":
+            return (
+                f"{self.base_url}timeseries_individual_buildings/"
+                f"by_state/upgrade={int(self.upgrade_id)!s}/"
                 f"state={self.state}/"
                 f"{self.bldg_id!s}-{int(self.upgrade_id)!s}.parquet"
             )
@@ -179,14 +186,14 @@ class BuildingID:
             else:
                 return (
                     f"{self.base_url}timeseries_individual_buildings/"
-                    f"by_state/upgrade={self.upgrade_id}/"
+                    f"by_state/upgrade={int(self.upgrade_id)!s}/"
                     f"state={self.state}/"
                     f"{self.bldg_id!s}-{int(self.upgrade_id)!s}.parquet"
                 )
         elif self.release_year == "2025":
             return (
                 f"{self.base_url}timeseries_individual_buildings/"
-                f"by_state/upgrade={self.upgrade_id}/"
+                f"by_state/upgrade={int(self.upgrade_id)!s}/"
                 f"state={self.state}/"
                 f"{self.bldg_id!s}-{int(self.upgrade_id)!s}.parquet"
             )
@@ -596,11 +603,14 @@ def fetch_bldg_data(
 
 
 if __name__ == "__main__":  # pragma: no cover
-    tmp_ids = [
-        BuildingID(
-            bldg_id=10, release_year="2022", res_com="resstock", weather="amy2018", release_number="1", upgrade_id="1"
-        )
+    releases_file = Path(__file__).parent.parent / "utils" / "buildstock_releases.json"
+    with open(releases_file) as f:
+        all_releases = json.load(f)
+
+    available_releases = [
+        release_name
+        for release_name, release_info in all_releases.items()
+        if "15min_load_curve" in release_info["available_data"]
     ]
-    tmp_data, tmp_failed = fetch_bldg_data(tmp_ids, ("load_curve_15min",), Path(__file__).parent / "data")
-    print(f"Downloaded files: {[str(path) for path in tmp_data]}")
-    print(f"Failed downloads: {tmp_failed}")
+
+    print(available_releases)

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -561,6 +561,6 @@ if __name__ == "__main__":  # pragma: no cover
             bldg_id=10, release_year="2022", res_com="resstock", weather="amy2018", release_number="1", upgrade_id="1"
         )
     ]
-    tmp_data, tmp_failed = fetch_bldg_data(tmp_ids, ("load_curve_15min"), Path(__file__).parent / "data")
+    tmp_data, tmp_failed = fetch_bldg_data(tmp_ids, ("load_curve_15min",), Path(__file__).parent / "data")
     print(f"Downloaded files: {[str(path) for path in tmp_data]}")
     print(f"Failed downloads: {tmp_failed}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 from buildstock_fetch.main import (
     BuildingID,
     NoBuildingDataError,
+    NoMetadataError,
     RequestedFileTypes,
     _parse_requested_file_type,
     download_bldg_data,
@@ -162,7 +163,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for resstock_tmy3_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2023 release - should raise NoBuildingDataError
@@ -170,7 +173,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for comstock_amy2018_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2024 comstock release - should raise NoBuildingDataError
@@ -178,7 +183,9 @@ def test_fetch_bldg_data(cleanup_downloads):
     file_type = ("hpxml", "schedule")
     output_dir = Path("data")
 
-    with pytest.raises(NoBuildingDataError, match="Building data is not available for comstock_amy2018_release_1"):
+    with pytest.raises(
+        NoBuildingDataError, match=f"Building data is not available for {bldg_ids[0].get_release_name()}"
+    ):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
 
     # Test 2024 resstock release - should work fine
@@ -198,3 +205,43 @@ def test_fetch_bldg_data(cleanup_downloads):
     assert Path(
         f"data/{bldg_ids[0].get_release_name()}/schedule/{bldg_ids[0].state}/bldg0000007-up01_schedule.csv"
     ).exists()
+
+
+def test_fetch_metadata(cleanup_downloads):
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2024", res_com="resstock", weather="tmy3", upgrade_id="1", release_number="2"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    print(downloaded_paths)
+    print(failed_downloads)
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(f"data/{bldg_ids[0].get_release_name()}/metadata/{bldg_ids[0].state}/metadata.parquet").exists()
+
+    # Test 2024 comstock release - should raise NoMetadataError
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+
+    with pytest.raises(NoMetadataError, match=f"Metadata is not available for {bldg_ids[0].get_release_name()}"):
+        fetch_bldg_data(bldg_ids, file_type, output_dir)
+
+    # Test 2025 comstock release - should raise NoMetadataError
+    bldg_ids = [
+        BuildingID(
+            bldg_id=7, release_year="2025", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="1"
+        )
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+
+    with pytest.raises(NoMetadataError, match=f"Metadata is not available for {bldg_ids[0].get_release_name()}"):
+        fetch_bldg_data(bldg_ids, file_type, output_dir)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 
 from buildstock_fetch.main import (
     BuildingID,
+    No15minLoadCurveError,
     NoBuildingDataError,
     NoMetadataError,
     RequestedFileTypes,
@@ -62,47 +63,47 @@ def test_parse_requested_file_type():
     assert _parse_requested_file_type(("hpxml", "schedule", "metadata")) == RequestedFileTypes(
         hpxml=True, schedule=True, metadata=True
     )
-    assert _parse_requested_file_type(("hpxml", "schedule", "metadata", "time_series_15min")) == RequestedFileTypes(
-        hpxml=True, schedule=True, metadata=True, time_series_15min=True
+    assert _parse_requested_file_type(("hpxml", "schedule", "metadata", "load_curve_15min")) == RequestedFileTypes(
+        hpxml=True, schedule=True, metadata=True, load_curve_15min=True
     )
     assert _parse_requested_file_type((
         "hpxml",
         "schedule",
         "metadata",
-        "time_series_15min",
-        "time_series_hourly",
-    )) == RequestedFileTypes(hpxml=True, schedule=True, metadata=True, time_series_15min=True, time_series_hourly=True)
+        "load_curve_15min",
+        "load_curve_hourly",
+    )) == RequestedFileTypes(hpxml=True, schedule=True, metadata=True, load_curve_15min=True, load_curve_hourly=True)
     assert _parse_requested_file_type((
         "hpxml",
         "schedule",
         "metadata",
-        "time_series_15min",
-        "time_series_hourly",
-        "time_series_daily",
+        "load_curve_15min",
+        "load_curve_hourly",
+        "load_curve_daily",
     )) == RequestedFileTypes(
         hpxml=True,
         schedule=True,
         metadata=True,
-        time_series_15min=True,
-        time_series_hourly=True,
-        time_series_daily=True,
+        load_curve_15min=True,
+        load_curve_hourly=True,
+        load_curve_daily=True,
     )
     assert _parse_requested_file_type((
         "hpxml",
         "schedule",
         "metadata",
-        "time_series_15min",
-        "time_series_hourly",
-        "time_series_daily",
-        "time_series_weekly",
+        "load_curve_15min",
+        "load_curve_hourly",
+        "load_curve_daily",
+        "load_curve_weekly",
     )) == RequestedFileTypes(
         hpxml=True,
         schedule=True,
         metadata=True,
-        time_series_15min=True,
-        time_series_hourly=True,
-        time_series_daily=True,
-        time_series_weekly=True,
+        load_curve_15min=True,
+        load_curve_hourly=True,
+        load_curve_daily=True,
+        load_curve_weekly=True,
     )
 
 
@@ -245,3 +246,140 @@ def test_fetch_metadata(cleanup_downloads):
 
     with pytest.raises(NoMetadataError, match=f"Metadata is not available for {bldg_ids[0].get_release_name()}"):
         fetch_bldg_data(bldg_ids, file_type, output_dir)
+
+
+def test_fetch_15min_load_curve(cleanup_downloads):
+    bldg_ids = [
+        BuildingID(
+            bldg_id=100041,
+            release_year="2021",
+            res_com="comstock",
+            weather="tmy3",
+            release_number="1",
+            upgrade_id="0",
+            state="AZ",
+        )
+    ]
+    file_type = ("load_curve_15min",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/load_curve_15min/{bldg_ids[0].state}/load_curve_15min.parquet"
+    ).exists()
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=10, release_year="2022", res_com="resstock", weather="amy2018", release_number="1", upgrade_id="1"
+        )
+    ]
+    file_type = ("load_curve_15min",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/load_curve_15min/{bldg_ids[0].state}/load_curve_15min.parquet"
+    ).exists()
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=237237,
+            release_year="2023",
+            res_com="comstock",
+            weather="amy2018",
+            release_number="1",
+            upgrade_id="1",
+            state="OH",
+        )
+    ]
+    file_type = ("load_curve_15min",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/load_curve_15min/{bldg_ids[0].state}/load_curve_15min.parquet"
+    ).exists()
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=100041,
+            release_year="2024",
+            res_com="resstock",
+            weather="tmy3",
+            release_number="1",
+            upgrade_id="0",
+            state="NY",
+        )
+    ]
+    with pytest.raises(
+        No15minLoadCurveError,
+        match=f"15 min load profile timeseries is not available for {bldg_ids[0].get_release_name()}",
+    ):
+        fetch_bldg_data(bldg_ids, file_type, output_dir)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=100000,
+            release_year="2024",
+            res_com="resstock",
+            weather="tmy3",
+            release_number="2",
+            upgrade_id="0",
+            state="OH",
+        ),
+        BuildingID(
+            bldg_id=100058,
+            release_year="2024",
+            res_com="resstock",
+            weather="tmy3",
+            release_number="2",
+            upgrade_id="2",
+            state="NY",
+        ),
+    ]
+    file_type = ("load_curve_15min",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/load_curve_15min/{bldg_ids[0].state}/load_curve_15min.parquet"
+    ).exists()
+    assert Path(
+        f"data/{bldg_ids[1].get_release_name()}/load_curve_15min/{bldg_ids[1].state}/load_curve_15min.parquet"
+    ).exists()
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=4849,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            release_number="1",
+            upgrade_id="0",
+            state="AK",
+        ),
+        BuildingID(
+            bldg_id=4850,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            release_number="1",
+            upgrade_id="0",
+            state="AK",
+        ),
+    ]
+    file_type = ("load_curve_15min",)
+    output_dir = Path("data")
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/load_curve_15min/{bldg_ids[0].state}/load_curve_15min.parquet"
+    ).exists()
+    assert Path(
+        f"data/{bldg_ids[1].get_release_name()}/load_curve_15min/{bldg_ids[1].state}/load_curve_15min.parquet"
+    ).exists()


### PR DESCRIPTION
## Summary

This PR includes code to create a consistent column schema for the end use load curve across all releases downloaded from the NREL s3 bucket.

## Implementation

The columns are renamed using a new function in `main.py`. Inside `main.py`, there's a dictionary called `COLUMN_RENAMES` that lists out different column names across different releases that should correspond to the same values. Someone with more domain knowledge in which columns correspond to the same value should look at this to confirm/add more columns.