### PR TITLE
Change boto3 version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.32.3",
-    "boto3~=1.33.0",
-    "botocore~=1.33.0",
+    "boto3>=1.33.0",
+    "botocore>=1.33.0",
     "pyarrow>=14.0.1",
     "polars>=0.20.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -108,6 +108,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.33.0" },
     { name = "botocore", specifier = ">=1.33.0" },
+    { name = "numpy", specifier = ">=1.26.4" },
     { name = "polars", specifier = ">=0.20.0" },
     { name = "pyarrow", specifier = ">=14.0.1" },
     { name = "requests", specifier = ">=2.32.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -103,8 +103,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "~=1.33.0" },
-    { name = "botocore", specifier = "~=1.33.0" },
+    { name = "boto3", specifier = ">=1.33.0" },
+    { name = "botocore", specifier = ">=1.33.0" },
     { name = "polars", specifier = ">=0.20.0" },
     { name = "pyarrow", specifier = ">=14.0.1" },
     { name = "requests", specifier = ">=2.32.3" },


### PR DESCRIPTION
## Summary

This PR changes the boto3 dependency requirement from ~= 1.33.0 to >=1.33.0 in order to make it compatible with other libraries

## Implementation

The boto3 requirement in `pyproject.toml` is modified.