### PR TITLE
Resolve weather station id's and create a mapping table

### DIFF
--- a/utils/resolve_weather_station_id.py
+++ b/utils/resolve_weather_station_id.py
@@ -1,0 +1,20 @@
+from buildstock_fetch.main import fetch_bldg_ids
+
+
+def resolve_weather_station_id(
+    product: str, release_year: str, weather_file: str, release_version: str, state: str, upgrade_id: str
+) -> str:
+    bldg_ids = fetch_bldg_ids(product, release_year, weather_file, release_version, state, upgrade_id)
+    return bldg_ids
+
+
+if __name__ == "__main__":
+    product = "resstock"
+    release_year = "2022"
+    weather_file = "amy2012"
+    release_version = "1"
+    state = "NY"
+    upgrade_id = "0"
+
+    bldg_ids = fetch_bldg_ids(product, release_year, weather_file, release_version, state, upgrade_id)
+    print(bldg_ids[:10])


### PR DESCRIPTION
## Summary

This PR includes code that resolves the weather station id for each bldg_id. This is done by downloding the hpxml file for the bldg_id, extracting out the weather station id, and creating a mapping metadata table for each bldg_id to its corresponding weather station id.

## Implementation

A new script is added inside `utils` called `resolve_weather_station_id.py` that takes care of this.

Closes #48