### PR TITLE
Deal with metadata file downloads for releases with county level metadata

### DIFF
--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -216,12 +216,12 @@ class BuildingID:
             self.release_year == "2025"
             and self.res_com == "comstock"
             and self.weather == "amy2018"
-            and self.release_number == "1"
+            and (self.release_number == "1" or self.release_number == "2")
         ):
-            return ""
-            # This release does not have a single national metadata file.
-            # Instead, it has a metadata file for each county.
-            # We need a way to download them all and combine based on the state
+            return (
+                f"{self.base_url}metadata_and_annual_results/by_state_and_county/full/parquet/"
+                f"state={self.state}/county={self._get_county_name()}/{self.state}_{self._get_county_name()}_upgrade{self.upgrade_id}.parquet"
+            )
         else:
             return ""
 

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -199,10 +199,14 @@ class BuildingID:
                 return f"{self.base_url}metadata/upgrade{str(int(self.upgrade_id)).zfill(2)}.parquet"
         elif self.release_year == "2024":
             if self.res_com == "comstock" and self.weather == "amy2018" and self.release_number == "2":
-                return ""
-                # This release does not have a single national metadata file.
-                # Instead, it has a metadata file for each county.
-                # We need a way to download them all and combine based on the state
+                if self.upgrade_id == "0":
+                    upgrade_filename = "baseline"
+                else:
+                    upgrade_filename = f"upgrade{str(int(self.upgrade_id)).zfill(2)}"
+                return (
+                    f"{self.base_url}metadata_and_annual_results/by_state_and_county/full/parquet/"
+                    f"state={self.state}/county={self._get_county_name()}/{self.state}_{self._get_county_name()}_{upgrade_filename}.parquet"
+                )
             else:
                 if self.upgrade_id == "0":
                     return f"{self.base_url}metadata/baseline.parquet"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -305,10 +305,20 @@ def test_fetch_metadata(cleanup_downloads):
             release_number="2",
         ),
         BuildingID(
-            bldg_id=658, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+            bldg_id=658,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
         ),
         BuildingID(
-            bldg_id=659, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+            bldg_id=659,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
         ),
     ]
     file_type = ("metadata",)
@@ -319,6 +329,56 @@ def test_fetch_metadata(cleanup_downloads):
     assert len(failed_downloads) == 0
     assert Path(
         f"data/{bldg_ids[0].get_release_name()}/metadata/state={bldg_ids[0].state}/upgrade={str(int(bldg_ids[0].upgrade_id)).zfill(2)}/metadata.parquet"
+    ).exists()
+
+    # Test 2024 comstock release
+    bldg_ids = [
+        BuildingID(
+            bldg_id=19713,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+        ),
+        BuildingID(
+            bldg_id=658,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+        ),
+        BuildingID(
+            bldg_id=70769,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+            state="NV",
+        ),
+        BuildingID(
+            bldg_id=68227,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+            state="NV",
+        ),
+    ]
+    file_type = ("metadata",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/metadata/state={bldg_ids[0].state}/upgrade={str(int(bldg_ids[0].upgrade_id)).zfill(2)}/metadata.parquet"
+    ).exists()
+    assert Path(
+        f"data/{bldg_ids[-1].get_release_name()}/metadata/state={bldg_ids[-1].state}/upgrade={str(int(bldg_ids[-1].upgrade_id)).zfill(2)}/metadata.parquet"
     ).exists()
 
     # Test 2025 comstock release - should fail

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -384,15 +384,54 @@ def test_fetch_metadata(cleanup_downloads):
     # Test 2025 comstock release - should fail
     bldg_ids = [
         BuildingID(
-            bldg_id=7, release_year="2025", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="1"
-        )
+            bldg_id=150914,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="MA",
+        ),
+        BuildingID(
+            bldg_id=149336,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="MA",
+        ),
+        BuildingID(
+            bldg_id=87123,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="MO",
+        ),
+        BuildingID(
+            bldg_id=87232,
+            release_year="2025",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="MO",
+        ),
     ]
     file_type = ("metadata",)
     output_dir = Path("data")
 
     downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
-    assert len(downloaded_paths) == 0
-    assert len(failed_downloads) == 1
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/metadata/state={bldg_ids[0].state}/upgrade={str(int(bldg_ids[0].upgrade_id)).zfill(2)}/metadata.parquet"
+    ).exists()
+    assert Path(
+        f"data/{bldg_ids[2].get_release_name()}/metadata/state={bldg_ids[2].state}/upgrade={str(int(bldg_ids[2].upgrade_id)).zfill(2)}/metadata.parquet"
+    ).exists()
 
 
 def test_fetch_metadata_relevant_bldg_id(cleanup_downloads):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -294,18 +294,32 @@ def test_fetch_metadata(cleanup_downloads):
         f"data/{bldg_ids[0].get_release_name()}/metadata/state={bldg_ids[0].state}/upgrade={str(int(bldg_ids[0].upgrade_id)).zfill(2)}/metadata.parquet"
     ).exists()
 
-    # Test 2024 comstock release - should fail
+    # Test 2024 comstock release
     bldg_ids = [
         BuildingID(
-            bldg_id=7, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
-        )
+            bldg_id=19713,
+            release_year="2024",
+            res_com="comstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+        ),
+        BuildingID(
+            bldg_id=658, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+        ),
+        BuildingID(
+            bldg_id=659, release_year="2024", res_com="comstock", weather="amy2018", upgrade_id="0", release_number="2"
+        ),
     ]
     file_type = ("metadata",)
     output_dir = Path("data")
 
     downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
-    assert len(downloaded_paths) == 0
-    assert len(failed_downloads) == 1
+    assert len(downloaded_paths) == 1
+    assert len(failed_downloads) == 0
+    assert Path(
+        f"data/{bldg_ids[0].get_release_name()}/metadata/state={bldg_ids[0].state}/upgrade={str(int(bldg_ids[0].upgrade_id)).zfill(2)}/metadata.parquet"
+    ).exists()
 
     # Test 2025 comstock release - should fail
     bldg_ids = [


### PR DESCRIPTION
## Summary

This PR includes code that deals with releases for which metadata is available at the county level.

## Implementation

The existing `get_metadata_url()` function in `BuildingID` is modified to handle these releases.

Closes #94