### PR TITLE
Implement load curve daily file type

### DIFF
--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -1731,6 +1731,8 @@ def fetch_bldg_data(
         total_files += len(bldg_ids)  # Add 15-minute load curve files
     if file_type_obj.load_curve_hourly:
         total_files += len(bldg_ids)  # Add hourly load curve files
+    if file_type_obj.load_curve_daily:
+        total_files += len(bldg_ids)  # Add daily load curve files
     if file_type_obj.load_curve_monthly:
         total_files += len(bldg_ids)  # Add monthly load curve files
     if file_type_obj.load_curve_annual:
@@ -1806,6 +1808,19 @@ def _execute_downloads(
 
     if file_type_obj.load_curve_hourly:
         aggregate_time_step = "hourly"
+        _download_aggregate_load_curves_parallel(
+            bldg_ids,
+            output_dir,
+            aggregate_time_step,
+            max_workers,
+            progress,
+            downloaded_paths,
+            failed_downloads,
+            console,
+        )
+
+    if file_type_obj.load_curve_daily:
+        aggregate_time_step = "daily"
         _download_aggregate_load_curves_parallel(
             bldg_ids,
             output_dir,

--- a/buildstock_fetch/main.py
+++ b/buildstock_fetch/main.py
@@ -749,10 +749,7 @@ def _create_aggregation_expressions(load_curve: pl.DataFrame, column_aggregation
 def _aggregate_load_curve_aggregate(
     load_curve: pl.DataFrame, aggregate_time_step: str, release_year: str
 ) -> pl.DataFrame:
-    """Aggregate the 15-minute load curve to specified time step based on aggregation rules.
-
-    Removes the last row to ensure complete aggregation periods.
-    """
+    """Aggregate the 15-minute load curve to specified time step based on aggregation rules."""
     # Read the aggregation rules from CSV
     if release_year == "2024":
         load_curve_map = LOAD_CURVE_COLUMN_AGGREGATION.joinpath("2024_resstock_load_curve_columns.csv")

--- a/buildstock_fetch/main_cli.py
+++ b/buildstock_fetch/main_cli.py
@@ -29,7 +29,7 @@ app = typer.Typer(
 BUILDSTOCK_RELEASES_FILE = str(files("buildstock_fetch").joinpath("data").joinpath("buildstock_releases.json"))
 
 # File types that haven't been implemented yet
-UNAVAILABLE_FILE_TYPES = ["load_curve_daily"]
+UNAVAILABLE_FILE_TYPES = []
 
 
 class InvalidProductError(Exception):

--- a/buildstock_fetch/main_cli.py
+++ b/buildstock_fetch/main_cli.py
@@ -29,7 +29,7 @@ app = typer.Typer(
 BUILDSTOCK_RELEASES_FILE = str(files("buildstock_fetch").joinpath("data").joinpath("buildstock_releases.json"))
 
 # File types that haven't been implemented yet
-UNAVAILABLE_FILE_TYPES = []
+UNAVAILABLE_FILE_TYPES: list[str] = []
 
 
 class InvalidProductError(Exception):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1513,7 +1513,7 @@ def _analyze_aggregation_data(load_curve_15min, load_curve_aggregate, column_agg
         _verify_aggregation_values(matching_15min, row, column_aggregations)
 
 
-def test_aggregation_functions(cleanup_downloads, load_curve_column_map):
+def test_aggregation_functions(cleanup_downloads):
     """Test aggregation functions for different time steps."""
     aggregate_timesteps = ["monthly", "hourly", "daily"]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1469,6 +1469,10 @@ def test_fetch_weather_file(cleanup_downloads, buildstock_releases_json):
 def _verify_aggregation_values(matching_15min, row, column_aggregations):
     """Verify that aggregated values match the expected aggregation of 15-minute data."""
     for name, rule in column_aggregations.items():
+        # Skip timedelta columns as they can't be compared with float tolerance
+        if isinstance(row[name], timedelta):
+            continue
+
         if rule == "sum":
             # Use a small tolerance for floating point precision issues
             assert abs(matching_15min[name].sum() - row[name]) < 0.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1472,6 +1472,9 @@ def _verify_aggregation_values(matching_15min, row, column_aggregations):
         if name == "timestamp":
             continue
 
+        if name not in matching_15min.columns:
+            continue
+
         if rule == "sum":
             # Use a small tolerance for floating point precision issues
             assert abs(matching_15min[name].sum() - row[name]) < 0.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1261,7 +1261,7 @@ def test_fetch_daily_load_curve(cleanup_downloads):
             state="IN",
         ),
     ]
-    file_type = ("load_curve_hourly",)
+    file_type = ("load_curve_daily",)
     output_dir = Path("data")
 
     downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
@@ -1269,11 +1269,11 @@ def test_fetch_daily_load_curve(cleanup_downloads):
     assert len(failed_downloads) == 0
     bldg_id = bldg_ids[0]
     assert Path(
-        f"data/{bldg_id.get_release_name()}/load_curve_hourly/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_hourly.parquet"
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
     ).exists()
     bldg_id = bldg_ids[1]
     assert Path(
-        f"data/{bldg_id.get_release_name()}/load_curve_hourly/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_hourly.parquet"
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
     ).exists()
 
     daily_load_curve = pl.read_parquet(downloaded_paths[0])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1500,6 +1500,6 @@ def test_aggregation_functions(cleanup_downloads, load_curve_column_map):
         if aggregate_timestep == "monthly":
             assert load_curve_aggregate.shape[0] == 12
         elif aggregate_timestep == "hourly":
-            assert load_curve_aggregate.shape[0] == 8784
+            assert load_curve_aggregate.shape[0] == 8760
         elif aggregate_timestep == "daily":
             assert load_curve_aggregate.shape[0] == 365

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1044,6 +1044,325 @@ def test_fetch_hourly_load_curve(cleanup_downloads):
     assert timestamps[1] - timestamps[0] == timedelta(hours=1)
 
 
+def test_fetch_daily_load_curve(cleanup_downloads):
+    # 2022 release
+    bldg_ids = [
+        BuildingID(
+            bldg_id=386459,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2012",
+            upgrade_id="0",
+            release_number="1",
+            state="ME",
+        ),
+        BuildingID(
+            bldg_id=247072,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2012",
+            upgrade_id="0",
+            release_number="1",
+            state="ME",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 366
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=43469,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2012",
+            upgrade_id="0",
+            release_number="1.1",
+            state="FL",
+        ),
+        BuildingID(
+            bldg_id=25395,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2012",
+            upgrade_id="0",
+            release_number="1.1",
+            state="FL",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 366
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=349561,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1.1",
+            state="CO",
+        ),
+        BuildingID(
+            bldg_id=547230,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1.1",
+            state="CO",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 365
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=37283,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="GA",
+        ),
+        BuildingID(
+            bldg_id=436794,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="GA",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 365
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=276508,
+            release_year="2022",
+            res_com="resstock",
+            weather="tmy3",
+            upgrade_id="0",
+            release_number="1",
+            state="DE",
+        ),
+        BuildingID(
+            bldg_id=330393,
+            release_year="2022",
+            res_com="resstock",
+            weather="tmy3",
+            upgrade_id="0",
+            release_number="1",
+            state="DE",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=394846,
+            release_year="2022",
+            res_com="resstock",
+            weather="tmy3",
+            upgrade_id="0",
+            release_number="1.1",
+            state="IN",
+        ),
+        BuildingID(
+            bldg_id=159923,
+            release_year="2022",
+            res_com="resstock",
+            weather="tmy3",
+            upgrade_id="0",
+            release_number="1.1",
+            state="IN",
+        ),
+    ]
+    file_type = ("load_curve_hourly",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_hourly/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_hourly.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_hourly/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_hourly.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 365
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    bldg_ids = [
+        BuildingID(
+            bldg_id=37283,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="GA",
+        ),
+        BuildingID(
+            bldg_id=436794,
+            release_year="2022",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="1",
+            state="GA",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 365
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+    # 2024 release - should work fine
+    bldg_ids = [
+        BuildingID(
+            bldg_id=173038,
+            release_year="2024",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+            state="RI",
+        ),
+        BuildingID(
+            bldg_id=119411,
+            release_year="2024",
+            res_com="resstock",
+            weather="amy2018",
+            upgrade_id="0",
+            release_number="2",
+            state="RI",
+        ),
+    ]
+    file_type = ("load_curve_daily",)
+    output_dir = Path("data")
+
+    downloaded_paths, failed_downloads = fetch_bldg_data(bldg_ids, file_type, output_dir)
+    assert len(downloaded_paths) == 2
+    assert len(failed_downloads) == 0
+    bldg_id = bldg_ids[0]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+    bldg_id = bldg_ids[1]
+    assert Path(
+        f"data/{bldg_id.get_release_name()}/load_curve_daily/state={bldg_id.state}/upgrade={str(int(bldg_id.upgrade_id)).zfill(2)}/bldg{bldg_id.bldg_id:07d}_load_curve_daily.parquet"
+    ).exists()
+
+    daily_load_curve = pl.read_parquet(downloaded_paths[0])
+    timestamps = daily_load_curve["timestamp"].to_list()
+    assert len(timestamps) == 365
+    assert timestamps[1] - timestamps[0] == timedelta(days=1)
+
+
 def test_fetch_weather_station_name(cleanup_downloads):
     bldg_ids = [
         BuildingID(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1469,8 +1469,7 @@ def test_fetch_weather_file(cleanup_downloads, buildstock_releases_json):
 def _verify_aggregation_values(matching_15min, row, column_aggregations):
     """Verify that aggregated values match the expected aggregation of 15-minute data."""
     for name, rule in column_aggregations.items():
-        # Skip timedelta columns as they can't be compared with float tolerance
-        if isinstance(row[name], timedelta):
+        if name == "timestamp":
             continue
 
         if rule == "sum":


### PR DESCRIPTION
## Summary

This PR includes code that allows the user to download daily load curves.

## Implementation

First, modified `main_cli.py` allows the user to select the daily load curve file type option. Next, in the `main.py` file, if the user selected the daily load curve option, the aggregate load curve function is called and the aggregate time step of "daily" is provided. This downloads the 15 min load curve, aggregates to daily timestep and saves the results.

Closes #97 