### PR TITLE
Create library for reading bsf downloads

### DIFF
--- a/buildstock_fetch/io.py
+++ b/buildstock_fetch/io.py
@@ -1,0 +1,632 @@
+"""
+Module for reading BuildStock data downloaded with bsf.
+
+Provides a user-friendly interface to read metadata and load curve data
+from locally downloaded BuildStock files.
+
+Usage:
+    from buildstock_fetch.io import BuildStockRead, BuildStockRelease, State
+
+    bsr = BuildStockRead(
+        data_path="./data",
+        release=BuildStockRelease.RES_2024_TMY3_2,
+        states=State.NY
+    )
+    metadata_df = bsr.read_metadata(upgrades=["0", "1", "2"])
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from buildstock_fetch.constants import BUILDSTOCK_RELEASES_FILE
+
+if TYPE_CHECKING:
+    pass
+
+
+class State(Enum):
+    """US State codes enum for BuildStock data."""
+
+    AL = "AL"
+    AK = "AK"
+    AZ = "AZ"
+    AR = "AR"
+    CA = "CA"
+    CO = "CO"
+    CT = "CT"
+    DE = "DE"
+    FL = "FL"
+    GA = "GA"
+    HI = "HI"
+    ID = "ID"
+    IL = "IL"
+    IN = "IN"
+    IA = "IA"
+    KS = "KS"
+    KY = "KY"
+    LA = "LA"
+    ME = "ME"
+    MD = "MD"
+    MA = "MA"
+    MI = "MI"
+    MN = "MN"
+    MS = "MS"
+    MO = "MO"
+    MT = "MT"
+    NE = "NE"
+    NV = "NV"
+    NH = "NH"
+    NJ = "NJ"
+    NM = "NM"
+    NY = "NY"
+    NC = "NC"
+    ND = "ND"
+    OH = "OH"
+    OK = "OK"
+    OR = "OR"
+    PA = "PA"
+    RI = "RI"
+    SC = "SC"
+    SD = "SD"
+    TN = "TN"
+    TX = "TX"
+    UT = "UT"
+    VT = "VT"
+    VA = "VA"
+    WA = "WA"
+    WV = "WV"
+    WI = "WI"
+    WY = "WY"
+    DC = "DC"
+
+
+def _load_releases_data() -> dict[str, dict[str, object]]:
+    """Load release data from JSON file."""
+    with open(BUILDSTOCK_RELEASES_FILE) as f:
+        data: dict[str, dict[str, object]] = json.load(f)
+        return data
+
+
+# Load releases data once at module import
+_RELEASES_DATA = _load_releases_data()
+
+
+class BuildStockRelease(Enum):
+    """BuildStock release enum with metadata attributes.
+
+    Each release contains metadata about:
+    - release_year: The year of the release
+    - res_com: Whether it's 'resstock' or 'comstock'
+    - weather: The weather file type (e.g., 'amy2018', 'tmy3')
+    - release_number: The version number
+    - upgrade_ids: List of available upgrade IDs
+    - available_data: List of available data types
+    """
+
+    def __init__(self, key: str) -> None:
+        self._key = key
+        data = _RELEASES_DATA[key]
+        self._release_year = data["release_year"]
+        self._res_com = data["res_com"]
+        self._weather = data["weather"]
+        self._release_number = data["release_number"]
+        self._upgrade_ids = data["upgrade_ids"]
+        self._available_data = data["available_data"]
+
+    @property
+    def key(self) -> str:
+        """The release key (e.g., 'res_2024_tmy3_2')."""
+        return str(self._key)
+
+    @property
+    def release_year(self) -> str:
+        """The year of the release."""
+        return str(self._release_year)
+
+    @property
+    def res_com(self) -> str:
+        """Whether it's 'resstock' or 'comstock'."""
+        return str(self._res_com)
+
+    @property
+    def weather(self) -> str:
+        """The weather file type."""
+        return str(self._weather)
+
+    @property
+    def release_number(self) -> str:
+        """The version number."""
+        return str(self._release_number)
+
+    @property
+    def upgrade_ids(self) -> list[str]:
+        """List of available upgrade IDs."""
+        ids = self._upgrade_ids
+        if isinstance(ids, list):
+            return [str(x) for x in ids]
+        return []
+
+    @property
+    def available_data(self) -> list[str]:
+        """List of available data types."""
+        data = self._available_data
+        if isinstance(data, list):
+            return [str(x) for x in data]
+        return []
+
+    # Create enum members from JSON keys
+    COM_2021_AMY2018_1 = "com_2021_amy2018_1"
+    COM_2021_TMY3_1 = "com_2021_tmy3_1"
+    RES_2021_AMY2018_1 = "res_2021_amy2018_1"
+    RES_2021_TMY3_1 = "res_2021_tmy3_1"
+    RES_2022_AMY2012_1_1 = "res_2022_amy2012_1.1"
+    RES_2022_AMY2012_1 = "res_2022_amy2012_1"
+    RES_2022_AMY2018_1_1 = "res_2022_amy2018_1.1"
+    RES_2022_AMY2018_1 = "res_2022_amy2018_1"
+    RES_2022_TMY3_1_1 = "res_2022_tmy3_1.1"
+    RES_2022_TMY3_1 = "res_2022_tmy3_1"
+    COM_2023_AMY2018_1 = "com_2023_amy2018_1"
+    COM_2023_AMY2018_2 = "com_2023_amy2018_2"
+    COM_2024_AMY2018_1 = "com_2024_amy2018_1"
+    COM_2024_AMY2018_2 = "com_2024_amy2018_2"
+    RES_2024_AMY2018_2 = "res_2024_amy2018_2"
+    RES_2024_TMY3_1 = "res_2024_tmy3_1"
+    RES_2024_TMY3_2 = "res_2024_tmy3_2"
+    COM_2025_AMY2012_2 = "com_2025_amy2012_2"
+    COM_2025_AMY2018_1 = "com_2025_amy2018_1"
+    COM_2025_AMY2018_2 = "com_2025_amy2018_2"
+    COM_2025_AMY2018_3 = "com_2025_amy2018_3"
+    RES_2025_AMY2012_1 = "res_2025_amy2012_1"
+    RES_2025_AMY2018_1 = "res_2025_amy2018_1"
+
+
+class DataNotFoundError(Exception):
+    """Raised when requested data is not found on disk."""
+
+    pass
+
+
+class MetadataNotFoundError(DataNotFoundError):
+    """Raised when metadata is not found on disk."""
+
+    pass
+
+
+class LoadCurveNotFoundError(DataNotFoundError):
+    """Raised when load curve data is not found on disk."""
+
+    pass
+
+
+class NoUpgradesOnDiskError(DataNotFoundError):
+    """Raised when no upgrades are found on disk."""
+
+    pass
+
+
+class InvalidUpgradeError(ValueError):
+    """Raised when an invalid upgrade is specified."""
+
+    pass
+
+
+class SampleSizeExceedsBuildingCountError(ValueError):
+    """Raised when sample_n exceeds the number of available buildings."""
+
+    pass
+
+
+class BuildStockRead:
+    """Reader class for BuildStock data downloaded with bsf.
+
+    This class provides methods to read metadata and load curve data
+    from locally downloaded BuildStock files.
+
+    Args:
+        data_path: Path to the data directory (local path or S3 path).
+        release: A BuildStockRelease enum member specifying the release.
+        states: Optional State or list of States to filter data.
+            If None, auto-detects states present on disk.
+        sample_n: Optional number of buildings to sample.
+        seed: Optional random seed for reproducible sampling.
+
+    Example:
+        >>> from buildstock_fetch.io import BuildStockRead, BuildStockRelease, State
+        >>> bsr = BuildStockRead(
+        ...     data_path="./data",
+        ...     release=BuildStockRelease.RES_2024_TMY3_2,
+        ...     states=State.NY
+        ... )
+        >>> metadata = bsr.read_metadata(upgrades=["0", "1"])
+    """
+
+    def __init__(
+        self,
+        data_path: str | Path,
+        release: BuildStockRelease,
+        states: State | list[State] | None = None,
+        sample_n: int | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self.path = Path(data_path)
+        self.release = self._validate_release(release)
+        self.states = self._validate_and_resolve_states(states)
+        self.sample_n = sample_n
+        self.seed = seed
+        self.sampled_bldgs: list[int] | None = None
+
+        # Set up sampling if sample_n is specified
+        if sample_n is not None:
+            self._setup_sampling()
+
+    def _validate_release(self, release: BuildStockRelease) -> BuildStockRelease:
+        """Validate that the release is a valid BuildStockRelease enum member."""
+        if not isinstance(release, BuildStockRelease):
+            raise TypeError(
+                f"Expected BuildStockRelease enum member, got {type(release).__name__}. "
+                f"Valid releases: {[r.name for r in BuildStockRelease]}"
+            )
+        return release
+
+    def _validate_and_resolve_states(self, states: State | list[State] | None) -> list[State]:
+        """Validate states and resolve them if not provided.
+
+        If states is None, detects which states are present on disk.
+        """
+        if states is not None:
+            return self._validate_states(states)
+
+        # Auto-detect states from disk
+        detected_states = self._detect_states_on_disk()
+        if not detected_states:
+            raise DataNotFoundError(
+                f"No states found on disk for release {self.release.key} at {self.path}. "
+                "Please download data using bsf first."
+            )
+
+        print(f"Auto-detected states on disk: {[s.value for s in detected_states]}")
+        return detected_states
+
+    def _validate_states(self, states: State | list[State]) -> list[State]:
+        """Validate that states are valid State enum members."""
+        state_list = [states] if isinstance(states, State) else list(states)
+
+        for state in state_list:
+            if not isinstance(state, State):
+                raise TypeError(
+                    f"Expected State enum member, got {type(state).__name__}. Valid states: {[s.name for s in State]}"
+                )
+        return state_list
+
+    def _detect_states_on_disk(self) -> list[State]:
+        """Detect which states have data on disk for the release."""
+        release_path = self.path / self.release.key
+        if not release_path.exists():
+            return []
+
+        # Look for state directories in metadata folder first
+        metadata_path = release_path / "metadata"
+        if metadata_path.exists():
+            return self._find_state_dirs(metadata_path)
+
+        # Fall back to load curve directories
+        for data_type in ["load_curve_15min", "load_curve_hourly", "load_curve_daily", "load_curve_annual"]:
+            data_path = release_path / data_type
+            if data_path.exists():
+                states = self._find_state_dirs(data_path)
+                if states:
+                    return states
+
+        return []
+
+    def _find_state_dirs(self, base_path: Path) -> list[State]:
+        """Find state directories in a path and return matching State enums."""
+        states: list[State] = []
+        if not base_path.exists():
+            return states
+
+        for item in base_path.iterdir():
+            if item.is_dir() and item.name.startswith("state="):
+                state_code = item.name.replace("state=", "")
+                try:
+                    states.append(State(state_code))
+                except ValueError:
+                    continue
+
+        return sorted(states, key=lambda s: s.value)
+
+    def _setup_sampling(self) -> None:
+        """Set up building sampling based on sample_n and seed."""
+        if self.sample_n is None:
+            return
+
+        # Get all unique bldg_ids from metadata
+        all_bldg_ids = self._get_all_bldg_ids_from_metadata()
+
+        if not all_bldg_ids:
+            raise MetadataNotFoundError(
+                f"Cannot sample buildings: no metadata found for release {self.release.key}. "
+                "Please download metadata using bsf first."
+            )
+
+        if self.sample_n > len(all_bldg_ids):
+            print(
+                f"Warning: sample_n ({self.sample_n}) exceeds available buildings ({len(all_bldg_ids)}). "
+                "Returning all buildings without sampling."
+            )
+            self.sampled_bldgs = None
+            return
+
+        # Sample bldg_ids
+        if self.seed is not None:
+            random.seed(self.seed)
+
+        self.sampled_bldgs = random.sample(all_bldg_ids, self.sample_n)
+        print(f"Sampled {len(self.sampled_bldgs)} buildings from {len(all_bldg_ids)} total.")
+
+    def _get_all_bldg_ids_from_metadata(self) -> list[int]:
+        """Get all unique bldg_ids from the first available upgrade metadata."""
+        for state in self.states:
+            # Find the first available upgrade on disk
+            upgrades_on_disk = self._get_upgrades_on_disk("metadata", state)
+            if not upgrades_on_disk:
+                continue
+
+            # Use the first available upgrade
+            upgrade = upgrades_on_disk[0]
+            metadata_path = (
+                self.path / self.release.key / "metadata" / f"state={state.value}" / f"upgrade={upgrade.zfill(2)}"
+            )
+
+            # Find parquet files
+            parquet_files = list(metadata_path.glob("*.parquet"))
+            if not parquet_files:
+                continue
+
+            # Read and get unique bldg_ids
+            try:
+                df = pl.scan_parquet(parquet_files).select("bldg_id").collect()
+                return df["bldg_id"].unique().to_list()
+            except Exception:
+                continue
+
+        return []
+
+    def _get_upgrades_on_disk(self, data_type: str, state: State) -> list[str]:
+        """Get list of upgrades available on disk for a given data type and state."""
+        base_path = self.path / self.release.key / data_type / f"state={state.value}"
+        if not base_path.exists():
+            return []
+
+        upgrades = []
+        for item in base_path.iterdir():
+            if item.is_dir() and item.name.startswith("upgrade="):
+                upgrade_id = item.name.replace("upgrade=", "").lstrip("0") or "0"
+                upgrades.append(upgrade_id)
+
+        return sorted(upgrades, key=lambda x: int(x))
+
+    def _validate_upgrades(self, upgrades: str | list[str] | None, data_type: str) -> tuple[list[str], list[str]]:
+        """Validate upgrades against release and disk.
+
+        Returns:
+            Tuple of (validated_upgrades, upgrades_on_disk)
+        """
+        # Get all upgrades available on disk across all states
+        all_upgrades_on_disk: set[str] = set()
+        for state in self.states:
+            upgrades_on_disk = self._get_upgrades_on_disk(data_type, state)
+            all_upgrades_on_disk.update(upgrades_on_disk)
+
+        if not all_upgrades_on_disk:
+            raise NoUpgradesOnDiskError(
+                f"No {data_type} found on disk for release {self.release.key} "
+                f"in states {[s.value for s in self.states]}. "
+                "Please download data using bsf first."
+            )
+
+        upgrades_on_disk_sorted = sorted(all_upgrades_on_disk, key=lambda x: int(x))
+
+        if upgrades is None:
+            # Use all upgrades found on disk
+            print(f"Using all upgrades found on disk: {upgrades_on_disk_sorted}")
+            return upgrades_on_disk_sorted, upgrades_on_disk_sorted
+
+        # Convert single upgrade to list
+        upgrade_list = [upgrades] if isinstance(upgrades, str) else list(upgrades)
+
+        # Validate each upgrade
+        release_upgrade_ids = self.release.upgrade_ids
+        for upgrade in upgrade_list:
+            # Check if upgrade belongs to the release
+            if upgrade not in release_upgrade_ids:
+                raise InvalidUpgradeError(
+                    f"Upgrade '{upgrade}' is not valid for release {self.release.key}. "
+                    f"Valid upgrades: {release_upgrade_ids}"
+                )
+            # Check if upgrade is on disk
+            if upgrade not in all_upgrades_on_disk:
+                raise DataNotFoundError(
+                    f"Upgrade '{upgrade}' is not found on disk for release {self.release.key}. "
+                    f"Available upgrades on disk: {upgrades_on_disk_sorted}. "
+                    "Please download the data using bsf first."
+                )
+
+        return upgrade_list, upgrades_on_disk_sorted
+
+    def _apply_sampling_filter(self, lf: pl.LazyFrame) -> pl.LazyFrame:
+        """Apply sampling filter if sampled_bldgs is set."""
+        if self.sampled_bldgs is not None:
+            return lf.filter(pl.col("bldg_id").is_in(self.sampled_bldgs))
+        return lf
+
+    def read_metadata(self, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Read metadata for the specified upgrades.
+
+        Args:
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+                If None, reads metadata for all upgrades found on disk.
+
+        Returns:
+            A Polars LazyFrame containing the metadata.
+            If multiple upgrades are specified, returns data for each bldg_id
+            in each upgrade (multiple records per bldg_id).
+
+        Raises:
+            MetadataNotFoundError: If metadata is not available for the release.
+            InvalidUpgradeError: If an invalid upgrade is specified.
+            DataNotFoundError: If the requested upgrade is not found on disk.
+        """
+        # Check if metadata is available for this release
+        if "metadata" not in self.release.available_data:
+            raise MetadataNotFoundError(
+                f"Metadata is not available for release {self.release.key}. "
+                "Please check the release documentation or download metadata using bsf."
+            )
+
+        validated_upgrades, _ = self._validate_upgrades(upgrades, "metadata")
+
+        # Collect all parquet files
+        parquet_files: list[Path] = []
+        for state in self.states:
+            for upgrade in validated_upgrades:
+                metadata_dir = (
+                    self.path / self.release.key / "metadata" / f"state={state.value}" / f"upgrade={upgrade.zfill(2)}"
+                )
+                if metadata_dir.exists():
+                    parquet_files.extend(metadata_dir.glob("*.parquet"))
+
+        if not parquet_files:
+            raise MetadataNotFoundError(
+                f"No metadata files found on disk for release {self.release.key} "
+                f"with upgrades {validated_upgrades} in states {[s.value for s in self.states]}. "
+                "Please download metadata using bsf first."
+            )
+
+        # Create lazy frame from all files
+        lf = pl.scan_parquet(parquet_files)
+
+        # Apply sampling filter if set
+        lf = self._apply_sampling_filter(lf)
+
+        return lf
+
+    def _read_load_curve(self, data_type: str, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Internal method to read load curve data.
+
+        Args:
+            data_type: Type of load curve (e.g., 'load_curve_15min').
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+
+        Returns:
+            A Polars LazyFrame containing the load curve data.
+        """
+        # Check if data type is available for this release
+        if data_type not in self.release.available_data:
+            raise LoadCurveNotFoundError(
+                f"{data_type} is not available for release {self.release.key}. "
+                f"Available data types: {self.release.available_data}. "
+                "Please download the data using bsf."
+            )
+
+        validated_upgrades, _ = self._validate_upgrades(upgrades, data_type)
+
+        # Collect all parquet files
+        parquet_files: list[Path] = []
+        for state in self.states:
+            for upgrade in validated_upgrades:
+                load_curve_dir = (
+                    self.path / self.release.key / data_type / f"state={state.value}" / f"upgrade={upgrade.zfill(2)}"
+                )
+                if load_curve_dir.exists():
+                    parquet_files.extend(load_curve_dir.glob("*.parquet"))
+
+        if not parquet_files:
+            raise LoadCurveNotFoundError(
+                f"No {data_type} files found on disk for release {self.release.key} "
+                f"with upgrades {validated_upgrades} in states {[s.value for s in self.states]}. "
+                "Please download the data using bsf first."
+            )
+
+        # Create lazy frame from all files
+        lf = pl.scan_parquet(parquet_files)
+
+        # Apply sampling filter if set
+        lf = self._apply_sampling_filter(lf)
+
+        return lf
+
+    def read_load_curve_15min(self, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Read 15-minute load curve data for the specified upgrades.
+
+        Args:
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+                If None, reads data for all upgrades found on disk.
+
+        Returns:
+            A Polars LazyFrame containing the 15-minute load curve data.
+
+        Raises:
+            LoadCurveNotFoundError: If 15-minute load curve data is not available.
+            InvalidUpgradeError: If an invalid upgrade is specified.
+            DataNotFoundError: If the requested upgrade is not found on disk.
+        """
+        return self._read_load_curve("load_curve_15min", upgrades)
+
+    def read_load_curve_hourly(self, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Read hourly load curve data for the specified upgrades.
+
+        Args:
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+                If None, reads data for all upgrades found on disk.
+
+        Returns:
+            A Polars LazyFrame containing the hourly load curve data.
+
+        Raises:
+            LoadCurveNotFoundError: If hourly load curve data is not available.
+            InvalidUpgradeError: If an invalid upgrade is specified.
+            DataNotFoundError: If the requested upgrade is not found on disk.
+        """
+        return self._read_load_curve("load_curve_hourly", upgrades)
+
+    def read_load_curve_daily(self, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Read daily load curve data for the specified upgrades.
+
+        Args:
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+                If None, reads data for all upgrades found on disk.
+
+        Returns:
+            A Polars LazyFrame containing the daily load curve data.
+
+        Raises:
+            LoadCurveNotFoundError: If daily load curve data is not available.
+            InvalidUpgradeError: If an invalid upgrade is specified.
+            DataNotFoundError: If the requested upgrade is not found on disk.
+        """
+        return self._read_load_curve("load_curve_daily", upgrades)
+
+    def read_load_curve_annual(self, upgrades: str | list[str] | None = None) -> pl.LazyFrame:
+        """Read annual load curve data for the specified upgrades.
+
+        Args:
+            upgrades: Single upgrade ID, list of upgrade IDs, or None.
+                If None, reads data for all upgrades found on disk.
+
+        Returns:
+            A Polars LazyFrame containing the annual load curve data.
+
+        Raises:
+            LoadCurveNotFoundError: If annual load curve data is not available.
+            InvalidUpgradeError: If an invalid upgrade is specified.
+            DataNotFoundError: If the requested upgrade is not found on disk.
+        """
+        return self._read_load_curve("load_curve_annual", upgrades)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,13 @@ ignore = [
   "B904",   # Within an `except` clause, raise exceptions with `raise ... from err`
   "TRY003", # Avoid specifying long messages outside the exception class
 ]
+"tests/test_io.py" = [
+  "PGH003", # Use specific rule codes when ignoring type issues (intentional for testing invalid types)
+]
+"buildstock_fetch/io.py" = [
+  "TRY003", # Avoid specifying long messages outside the exception class (user-facing error messages)
+  "S112",   # try-except-continue (intentional for graceful degradation)
+]
 
 [tool.ruff.format]
 preview = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest fixtures for all test modules."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def cleanup_downloads():
+    """Fixture to clean up downloaded data before and after tests.
+
+    This fixture:
+    1. Removes any existing 'data' directory before the test runs
+    2. Yields control to the test
+    3. Removes the 'data' directory after the test completes
+
+    This ensures each test starts with a clean slate and doesn't leave
+    downloaded files behind.
+    """
+    # Setup - clean up any existing files before test
+    data_dir = Path("data")
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+
+    yield
+
+    # Teardown - clean up downloaded files after test
+    if data_dir.exists():
+        shutil.rmtree(data_dir)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,573 @@
+"""Tests for the io module.
+
+These tests use real S3 downloads (like test_main.py) to ensure BuildStockRead
+is tested against the actual directory structure that bsf creates. If the S3
+structure changes, these tests will fail loudly.
+"""
+
+import sys
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+from buildstock_fetch.building import BuildingID
+from buildstock_fetch.io import (
+    BuildStockRead,
+    BuildStockRelease,
+    DataNotFoundError,
+    InvalidUpgradeError,
+    LoadCurveNotFoundError,
+    NoUpgradesOnDiskError,
+    State,
+)
+from buildstock_fetch.main import fetch_bldg_data
+
+# =============================================================================
+# Tests for State Enum
+# =============================================================================
+
+
+class TestStateEnum:
+    """Tests for the State enum."""
+
+    def test_state_enum_values(self):
+        """Test that State enum contains expected values."""
+        assert State.NY.value == "NY"
+        assert State.CA.value == "CA"
+        assert State.TX.value == "TX"
+
+    def test_state_enum_all_states(self):
+        """Test that State enum contains all 50 states + DC."""
+        # 50 states + DC = 51
+        assert len(State) == 51
+
+    def test_state_enum_membership(self):
+        """Test that we can check membership correctly."""
+        assert State("NY") == State.NY
+        with pytest.raises(ValueError):
+            State("INVALID")
+
+
+# =============================================================================
+# Tests for BuildStockRelease Enum
+# =============================================================================
+
+
+class TestBuildStockReleaseEnum:
+    """Tests for the BuildStockRelease enum."""
+
+    def test_release_enum_values(self):
+        """Test that BuildStockRelease enum contains expected values."""
+        assert BuildStockRelease.RES_2024_TMY3_2.key == "res_2024_tmy3_2"
+        assert BuildStockRelease.COM_2024_AMY2018_2.key == "com_2024_amy2018_2"
+
+    def test_release_enum_attributes(self):
+        """Test that BuildStockRelease enum has correct attributes."""
+        release = BuildStockRelease.RES_2024_TMY3_2
+        assert release.release_year == "2024"
+        assert release.res_com == "resstock"
+        assert release.weather == "tmy3"
+        assert release.release_number == "2"
+        assert isinstance(release.upgrade_ids, list)
+        assert isinstance(release.available_data, list)
+
+    def test_release_enum_upgrade_ids(self):
+        """Test that upgrade_ids are correctly loaded."""
+        release = BuildStockRelease.RES_2024_TMY3_2
+        assert "0" in release.upgrade_ids
+        assert "1" in release.upgrade_ids
+
+    def test_release_enum_available_data(self):
+        """Test that available_data is correctly loaded."""
+        release = BuildStockRelease.RES_2024_TMY3_2
+        assert "metadata" in release.available_data
+        assert "load_curve_15min" in release.available_data
+
+
+# =============================================================================
+# Tests for BuildStockRead Validation
+# =============================================================================
+
+
+class TestBuildStockReadValidation:
+    """Tests for BuildStockRead validation methods."""
+
+    def test_validate_release_invalid_type(self):
+        """Test that invalid release type raises TypeError."""
+        with pytest.raises(TypeError, match="Expected BuildStockRelease enum member"):
+            BuildStockRead(
+                data_path="./data",
+                release="res_2024_tmy3_2",  # type: ignore
+                states=State.NY,
+            )
+
+    def test_validate_release_invalid_string(self):
+        """Test that string release raises TypeError."""
+        with pytest.raises(TypeError, match="Expected BuildStockRelease enum member"):
+            BuildStockRead(
+                data_path="./data",
+                release="invalid_release",  # type: ignore
+                states=State.NY,
+            )
+
+    def test_validate_states_invalid_type(self):
+        """Test that invalid state type raises TypeError."""
+        with pytest.raises(TypeError, match="Expected State enum member"):
+            BuildStockRead(
+                data_path="./data",
+                release=BuildStockRelease.RES_2024_TMY3_2,
+                states="NY",  # type: ignore
+            )
+
+    def test_validate_states_invalid_list_type(self):
+        """Test that list with invalid state type raises TypeError."""
+        with pytest.raises(TypeError, match="Expected State enum member"):
+            BuildStockRead(
+                data_path="./data",
+                release=BuildStockRelease.RES_2024_TMY3_2,
+                states=[State.NY, "CA"],  # type: ignore
+            )
+
+    def test_validate_states_single_state(self, cleanup_downloads):
+        """Test that single State is accepted and converted to list."""
+        # Download minimal data
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+        assert bsr.states == [State.NY]
+
+    def test_validate_states_list_of_states(self, cleanup_downloads):
+        """Test that list of States is accepted."""
+        # Download data for NY and OH
+        bldg_ids = [
+            BuildingID(bldg_id=7, upgrade_id="0", state="NY"),
+            BuildingID(bldg_id=100000, upgrade_id="0", state="OH", release_number="2"),
+        ]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=[State.NY, State.OH],
+        )
+        assert State.NY in bsr.states
+        assert State.OH in bsr.states
+
+
+# =============================================================================
+# Tests for Auto-detection of States
+# =============================================================================
+
+
+class TestBuildStockReadAutoDetectStates:
+    """Tests for auto-detection of states on disk."""
+
+    def test_auto_detect_states_from_metadata(self, cleanup_downloads):
+        """Test auto-detection of states from metadata directory."""
+        # Download data for NY and OH
+        bldg_ids = [
+            BuildingID(bldg_id=7, upgrade_id="0", state="NY"),
+            BuildingID(bldg_id=100000, upgrade_id="0", state="OH", release_number="2"),
+        ]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=None,
+        )
+
+        assert State.NY in bsr.states
+        assert State.OH in bsr.states
+
+    def test_auto_detect_states_no_data(self, tmp_path):
+        """Test that DataNotFoundError is raised when no data on disk."""
+        with pytest.raises(DataNotFoundError, match="No states found on disk"):
+            BuildStockRead(
+                data_path=tmp_path / "nonexistent",
+                release=BuildStockRelease.RES_2024_TMY3_2,
+                states=None,
+            )
+
+
+# =============================================================================
+# Tests for Upgrade Validation
+# =============================================================================
+
+
+class TestBuildStockReadUpgradeValidation:
+    """Tests for upgrade validation in read methods."""
+
+    def test_validate_upgrades_invalid_upgrade(self, cleanup_downloads):
+        """Test that invalid upgrade raises InvalidUpgradeError."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        with pytest.raises(InvalidUpgradeError, match="is not valid for release"):
+            bsr.read_metadata(upgrades="999")
+
+    def test_validate_upgrades_not_on_disk(self, cleanup_downloads):
+        """Test that upgrade not on disk raises DataNotFoundError."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        # Upgrade 5 is valid for the release but not downloaded
+        with pytest.raises(DataNotFoundError, match="is not found on disk"):
+            bsr.read_metadata(upgrades="5")
+
+    def test_validate_upgrades_no_upgrades_on_disk(self, cleanup_downloads):
+        """Test that NoUpgradesOnDiskError is raised when no upgrades found."""
+        # Create empty directory structure without metadata files
+        empty_dir = Path("data/res_2024_tmy3_2/metadata/state=NY")
+        empty_dir.mkdir(parents=True, exist_ok=True)
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        with pytest.raises(NoUpgradesOnDiskError, match="No metadata found on disk"):
+            bsr.read_metadata()
+
+
+# =============================================================================
+# Tests for read_metadata()
+# =============================================================================
+
+
+class TestBuildStockReadMetadata:
+    """Tests for read_metadata method."""
+
+    def test_read_metadata_single_upgrade(self, cleanup_downloads):
+        """Test reading metadata for a single upgrade."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        metadata = bsr.read_metadata(upgrades="0")
+        assert isinstance(metadata, pl.LazyFrame)
+
+        df = metadata.collect()
+        assert "bldg_id" in df.columns
+        assert df.height > 0  # Real metadata has many buildings
+
+    def test_read_metadata_multiple_upgrades(self, cleanup_downloads):
+        """Test reading metadata for multiple upgrades."""
+        bldg_ids = [
+            BuildingID(bldg_id=7, upgrade_id="0"),
+            BuildingID(bldg_id=7, upgrade_id="1"),
+        ]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        metadata = bsr.read_metadata(upgrades=["0", "1"])
+        df = metadata.collect()
+
+        # Should have records from both upgrades
+        assert 0 in df["upgrade"].to_list()
+        assert 1 in df["upgrade"].to_list()
+
+    def test_read_metadata_auto_detect_upgrades(self, cleanup_downloads):
+        """Test reading metadata with auto-detected upgrades."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        # Call without specifying upgrades - should auto-detect
+        metadata = bsr.read_metadata()
+        df = metadata.collect()
+        assert df.height > 0
+
+
+# =============================================================================
+# Tests for Load Curve Reading
+# =============================================================================
+
+
+class TestBuildStockReadLoadCurves:
+    """Tests for load curve reading methods."""
+
+    def test_read_load_curve_15min(self, cleanup_downloads):
+        """Test reading 15-minute load curve data."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("load_curve_15min",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        load_curve = bsr.read_load_curve_15min(upgrades="0")
+        assert isinstance(load_curve, pl.LazyFrame)
+
+        df = load_curve.collect()
+        assert df.height > 0
+        assert "timestamp" in df.columns
+        assert "bldg_id" in df.columns
+
+    def test_read_load_curve_hourly(self, cleanup_downloads):
+        """Test reading hourly load curve data."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("load_curve_hourly",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        load_curve = bsr.read_load_curve_hourly(upgrades="0")
+        assert isinstance(load_curve, pl.LazyFrame)
+
+        df = load_curve.collect()
+        assert df.height > 0
+        assert "timestamp" in df.columns
+
+    def test_read_load_curve_daily(self, cleanup_downloads):
+        """Test reading daily load curve data."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("load_curve_daily",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        load_curve = bsr.read_load_curve_daily(upgrades="0")
+        assert isinstance(load_curve, pl.LazyFrame)
+
+        df = load_curve.collect()
+        assert df.height > 0
+        assert "timestamp" in df.columns
+
+    def test_read_load_curve_annual(self, cleanup_downloads):
+        """Test reading annual load curve data."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("load_curve_annual",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        load_curve = bsr.read_load_curve_annual(upgrades="0")
+        assert isinstance(load_curve, pl.LazyFrame)
+
+        df = load_curve.collect()
+        assert df.height > 0
+        assert "bldg_id" in df.columns
+
+    def test_read_load_curve_not_available_for_release(self, cleanup_downloads):
+        """Test that LoadCurveNotFoundError is raised for unavailable data type in release."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        # RES_2024_TMY3_2 should have load_curve_15min available, but not on disk
+        with pytest.raises((LoadCurveNotFoundError, NoUpgradesOnDiskError)):
+            bsr.read_load_curve_15min(upgrades="0")
+
+
+# =============================================================================
+# Tests for Sampling
+# =============================================================================
+
+
+class TestBuildStockReadSampling:
+    """Tests for sampling functionality."""
+
+    def test_sampling_with_seed(self, cleanup_downloads):
+        """Test that sampling with seed is reproducible."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        # Create two readers with same seed
+        bsr1 = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+            sample_n=100,
+            seed=42,
+        )
+
+        bsr2 = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+            sample_n=100,
+            seed=42,
+        )
+
+        # Should have same sampled buildings
+        assert bsr1.sampled_bldgs == bsr2.sampled_bldgs
+
+    def test_sampling_filters_metadata(self, cleanup_downloads):
+        """Test that sampling correctly filters metadata."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+            sample_n=50,
+            seed=42,
+        )
+
+        metadata = bsr.read_metadata(upgrades="0")
+        df = metadata.collect()
+
+        # Should only have sampled buildings
+        assert df["bldg_id"].n_unique() == 50
+
+    def test_sample_n_exceeds_buildings(self, cleanup_downloads):
+        """Test warning when sample_n exceeds available buildings."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        # Request more samples than available buildings
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+            sample_n=1000000,  # Way more than available
+        )
+
+        # Should not sample (sampled_bldgs should be None)
+        assert bsr.sampled_bldgs is None
+
+
+# =============================================================================
+# Tests for Multiple States
+# =============================================================================
+
+
+class TestBuildStockReadMultipleStates:
+    """Tests for reading data from multiple states."""
+
+    def test_read_metadata_multiple_states(self, cleanup_downloads):
+        """Test reading metadata from multiple states."""
+        bldg_ids = [
+            BuildingID(bldg_id=7, upgrade_id="0", state="NY"),
+            BuildingID(bldg_id=100000, upgrade_id="0", state="OH", release_number="2"),
+        ]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=[State.NY, State.OH],
+        )
+
+        metadata = bsr.read_metadata(upgrades="0")
+        df = metadata.collect()
+
+        # Should have buildings from both states
+        states_in_result = df["in.state"].unique().to_list()
+        assert "NY" in states_in_result
+        assert "OH" in states_in_result
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+
+class TestBuildStockReadIntegration:
+    """Integration tests for BuildStockRead."""
+
+    def test_returns_lazyframe(self, cleanup_downloads):
+        """Test that all read methods return LazyFrame."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        result = bsr.read_metadata(upgrades="0")
+        assert isinstance(result, pl.LazyFrame)
+
+    def test_path_as_string(self, cleanup_downloads):
+        """Test that string paths work correctly."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(bldg_ids, ("metadata",), Path("data"))
+
+        bsr = BuildStockRead(
+            data_path="data",  # Pass as string
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        result = bsr.read_metadata(upgrades="0")
+        assert isinstance(result, pl.LazyFrame)
+
+    def test_read_multiple_data_types(self, cleanup_downloads):
+        """Test reading multiple data types for same building."""
+        bldg_ids = [BuildingID(bldg_id=7, upgrade_id="0")]
+        fetch_bldg_data(
+            bldg_ids,
+            ("metadata", "load_curve_15min", "load_curve_hourly"),
+            Path("data"),
+        )
+
+        bsr = BuildStockRead(
+            data_path="data",
+            release=BuildStockRelease.RES_2024_TMY3_2,
+            states=State.NY,
+        )
+
+        # All should work
+        metadata = bsr.read_metadata(upgrades="0")
+        lc_15min = bsr.read_load_curve_15min(upgrades="0")
+        lc_hourly = bsr.read_load_curve_hourly(upgrades="0")
+
+        assert metadata.collect().height > 0
+        assert lc_15min.collect().height > 0
+        assert lc_hourly.collect().height > 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -27,20 +26,6 @@ from buildstock_fetch.main import (
 @pytest.fixture(scope="function")
 def buildstock_releases():
     return BuildstockReleases.from_json()
-
-
-@pytest.fixture(scope="function")
-def cleanup_downloads():
-    # Setup - clean up any existing files before test
-    data_dir = Path("data")
-    if data_dir.exists():
-        shutil.rmtree(data_dir)
-
-    yield
-
-    # Teardown - clean up downloaded files after test
-    if data_dir.exists():
-        shutil.rmtree(data_dir)
 
 
 def test_fetch_bldg_ids():


### PR DESCRIPTION
## Summary
Implements issue #131 to create a Python library for reading downloaded buildstock-fetch data using Polars.

- Added `State` enum with all 50 US states + DC
- Added `BuildStockRelease` enum that loads release metadata from buildstock_releases.json
- Added `BuildStockRead` class for reading metadata and load curves with:
  - Auto-detection of states on disk
  - Auto-detection of available upgrades
  - Upgrade validation against release definitions
  - Building ID sampling with reproducible seeds
  - Support for reading metadata, 15min/hourly/daily/annual load curves
  - Multi-state data reading

## Usage Examples

### Basic Usage - Read metadata for a single state
```python
from buildstock_fetch.io import BuildStockRead, BuildStockRelease, State

# Initialize reader
bsr = BuildStockRead(
    data_path="./data",
    release=BuildStockRelease.RES_2024_TMY3_2,
    states=State.CA,
)

# Read metadata (auto-detects available upgrades)
metadata = bsr.read_metadata()
df = metadata.collect()
print(df)
```

### Read specific upgrades
```python
# Read only baseline (upgrade 0)
metadata = bsr.read_metadata(upgrades="0")

# Read multiple upgrades
metadata = bsr.read_metadata(upgrades=["0", "1", "2"])
```

### Read load curves
```python
# Read 15-minute load curves
lc_15min = bsr.read_load_curve_15min(upgrades="0")
df = lc_15min.collect()

# Read hourly load curves
lc_hourly = bsr.read_load_curve_hourly(upgrades="0")

# Read daily load curves
lc_daily = bsr.read_load_curve_daily(upgrades="0")

# Read annual load curves
lc_annual = bsr.read_load_curve_annual(upgrades="0")
```

### Multi-state analysis
```python
# Auto-detect all states on disk
bsr = BuildStockRead(
    data_path="./data",
    release=BuildStockRelease.RES_2024_TMY3_2,
    states=None,  # Auto-detect
)

# Or specify multiple states
bsr = BuildStockRead(
    data_path="./data",
    release=BuildStockRelease.RES_2024_TMY3_2,
    states=[State.CA, State.NY, State.TX],
)

metadata = bsr.read_metadata()
df = metadata.collect()
```

### Sampling for faster analysis
```python
# Sample 1000 random buildings with reproducible seed
bsr = BuildStockRead(
    data_path="./data",
    release=BuildStockRelease.RES_2024_TMY3_2,
    states=State.CA,
    sample_n=1000,
    seed=42,
)

# All read methods will automatically filter to sampled buildings
metadata = bsr.read_metadata()
load_curves = bsr.read_load_curve_15min()
```

### Working with LazyFrames
All read methods return Polars LazyFrames for efficient memory usage:

```python
# Chain operations before collecting
result = (
    bsr.read_metadata(upgrades="0")
    .filter(pl.col("in.heating_fuel") == "natural gas")
    .select(["bldg_id", "in.state", "in.heating_fuel"])
    .collect()
)

# Join metadata with load curves
metadata = bsr.read_metadata(upgrades="0")
load_curves = bsr.read_load_curve_15min(upgrades="0")

joined = (
    load_curves
    .join(metadata, on=["bldg_id", "upgrade"], how="left")
    .collect()
)
```

## Test Strategy
Tests use real S3 downloads (like test_main.py) to ensure BuildStockRead works with actual directory structures from the NREL bucket. This ensures tests will fail loudly if the S3 bucket structure changes.

- Created shared conftest.py with cleanup_downloads fixture
- Added comprehensive tests for enums, validation, reading, sampling, and multi-state scenarios
- Tests download minimal data (a few building IDs) to balance coverage and speed

## Files Changed
- `buildstock_fetch/io.py` - New module with State, BuildStockRelease, and BuildStockRead
- `tests/test_io.py` - Comprehensive integration tests using real S3 downloads
- `tests/conftest.py` - Shared fixtures for test cleanup
- `tests/test_main.py` - Removed duplicate cleanup_downloads fixture, removed unused import
- `pyproject.toml` - Added linting ignores for intentional patterns

Closes #131